### PR TITLE
fixed custom background color not working

### DIFF
--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.m
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.m
@@ -109,9 +109,11 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     
     NSLog(@"%@  %f", attributes[CLCalendarBackgroundImageColor],  self.selectedDatePrintFontSize);
     self.backgroundImageColor = attributes[CLCalendarBackgroundImageColor];
+    [self refreshBackgroundImageColor];
     
     [self setNeedsDisplay];
 }
+
 -(UIView *)dailyInfoSubViewContainer
 {
     if(!_dailyInfoSubViewContainer){
@@ -126,6 +128,7 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     }
     return _dailyInfoSubViewContainer;
 }
+
 -(UIImageView *)weatherIcon
 {
     if(!_weatherIcon){
@@ -133,6 +136,7 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     }
     return _weatherIcon;
 }
+
 -(UILabel *)dateInfoLabel
 {
     if(!_dateInfoLabel){
@@ -144,6 +148,7 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     _dateInfoLabel.textColor = self.selectedDatePrintColor;
     return _dateInfoLabel;
 }
+
 -(UIView *)dayTitleSubViewContainer
 {
     if(!_dayTitleSubViewContainer){
@@ -155,6 +160,7 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     return _dayTitleSubViewContainer;
     
 }
+
 -(UIView *)dailySubViewContainer
 {
     if(!_dailySubViewContainer){
@@ -165,6 +171,7 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     }
     return _dailySubViewContainer;
 }
+
 -(UIImageView *)backgroundImageView
 {
     if(!_backgroundImageView){
@@ -192,9 +199,19 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
         [recognizerLeft setDirection:UISwipeGestureRecognizerDirectionLeft];
         [_backgroundImageView addGestureRecognizer:recognizerLeft];
     }
-    _backgroundImageView.backgroundColor = self.backgroundImageColor? self.backgroundImageColor : [UIColor colorWithPatternImage:[UIImage calendarBackgroundImage:self.bounds.size.height]];;
+    
+    [self refreshBackgroundImageColor];
+    
     return _backgroundImageView;
 }
+
+- (void)refreshBackgroundImageColor
+{
+    _backgroundImageView.backgroundColor = self.backgroundImageColor
+        ? self.backgroundImageColor
+        : [UIColor colorWithPatternImage:[UIImage calendarBackgroundImage:self.bounds.size.height]];
+}
+
 -(void)initDailyViews
 {
     CGFloat dailyWidth = self.bounds.size.width/WEEKLY_VIEW_COUNT;
@@ -280,15 +297,18 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     
     self.dateInfoLabel.text = strDate;
 }
+
 -(void)dailyInfoViewDidClick: (UIGestureRecognizer *)tap
 {
     //Click to jump back to today
     [self redrawToDate:[NSDate new] ];
 }
+
 -(void)dayTitleViewDidClick: (UIGestureRecognizer *)tap
 {
     [self redrawToDate:((DayTitleLabel *)tap.view).date];
 }
+
 -(void)redrawToDate:(NSDate *)dt
 {
     if(![dt isWithinDate:self.startDate toDate:self.endDate]){
@@ -298,11 +318,13 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     
     [self dailyCalendarViewDidSelect:dt];
 }
+
 -(void)redrawCalenderData
 {
     [self redrawToDate:self.selectedDate];
     
 }
+
 -(void)adjustDailyInfoLabelAndWeatherIcon: (BOOL)blnShowWeatherIcon
 {
     self.dateInfoLabel.textAlignment = (blnShowWeatherIcon)?NSTextAlignmentLeft:NSTextAlignmentCenter;
@@ -326,10 +348,12 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
 {
     [self delegateSwipeAnimation: NO blnToday:NO selectedDate:nil];
 }
+
 -(void)swipeRight: (UISwipeGestureRecognizer *)swipe
 {
     [self delegateSwipeAnimation: YES blnToday:NO selectedDate:nil];
 }
+
 -(void)delegateSwipeAnimation: (BOOL)blnSwipeRight blnToday: (BOOL)blnToday selectedDate:(NSDate *)selectedDate
 {
     CATransition *animation = [CATransition animation];

--- a/CLWeeklyCalendarView/ViewController.m
+++ b/CLWeeklyCalendarView/ViewController.m
@@ -47,6 +47,7 @@ static CGFloat CALENDER_VIEW_HEIGHT = 150.f;
 {
     return @{
              CLCalendarWeekStartDay : @2,                 //Start Day of the week, from 1-7 Mon-Sun -- default 1
+//             CLCalendarBackgroundImageColor: [UIColor redColor],
 //             CLCalendarDayTitleTextColor : [UIColor yellowColor],
 //             CLCalendarSelectedDatePrintColor : [UIColor greenColor],
              };


### PR DESCRIPTION
The custom attributes delegate function is called after the backgroundImageView call (which sets the color), hence the custom color was never being applied. Changed to refreshing background color with each delegate call.
