### PR TITLE
Added 8 new CLWeeklyCalendarViewDelegate behavior attributes for customizing colors

### DIFF
--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.h
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.h
@@ -12,6 +12,14 @@
 // Keys for customize the calendar behavior
 extern NSString *const CLCalendarWeekStartDay;    //The Day of weekStart from 1 - 7 - Default: 1
 extern NSString *const CLCalendarDayTitleTextColor; //Day Title text color,  Mon, Tue, etc label text color
+extern NSString *const CLCalendarPastDayNumberTextColor;    //Day number text color for dates in the past
+extern NSString *const CLCalendarFutureDayNumberTextColor;  //Day number text color for dates in the future
+extern NSString *const CLCalendarCurrentDayNumberTextColor; //Day number text color for today
+extern NSString *const CLCalendarSelectedDayNumberTextColor;    //Day number text color for the selected day
+extern NSString *const CLCalendarSelectedCurrentDayNumberTextColor; //Day number text color when today is selected
+extern NSString *const CLCalendarCurrentDayNumberBackgroundColor;   //Day number background color for today when not selected
+extern NSString *const CLCalendarSelectedDayNumberBackgroundColor;  //Day number background color for selected day
+extern NSString *const CLCalendarSelectedCurrentDayNumberBackgroundColor;   //Day number background color when today is selected
 extern NSString *const CLCalendarSelectedDatePrintFormat;   //Selected Date print format,  - Default: @"EEE, d MMM yyyy"
 extern NSString *const CLCalendarSelectedDatePrintColor;    //Selected Date print text color -Default: [UIColor whiteColor]
 extern NSString *const CLCalendarSelectedDatePrintFontSize; //Selected Date print font size - Default : 13.f

--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.m
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.m
@@ -36,6 +36,14 @@
 //Attribute Keys
 NSString *const CLCalendarWeekStartDay = @"CLCalendarWeekStartDay";
 NSString *const CLCalendarDayTitleTextColor = @"CLCalendarDayTitleTextColor";
+NSString *const CLCalendarPastDayNumberTextColor = @"CLCalendarPastDayNumberTextColor";
+NSString *const CLCalendarFutureDayNumberTextColor = @"CLCalendarFutureDayNumberTextColor";
+NSString *const CLCalendarCurrentDayNumberTextColor = @"CLCalendarCurrentDayNumberTextColor";
+NSString *const CLCalendarSelectedDayNumberTextColor = @"CLCalendarSelectedDayNumberTextColor";
+NSString *const CLCalendarSelectedCurrentDayNumberTextColor = @"CLCalendarSelectedCurrentDayNumberTextColor";
+NSString *const CLCalendarCurrentDayNumberBackgroundColor = @"CLCalendarCurrentDayNumberBackgroundColor";
+NSString *const CLCalendarSelectedDayNumberBackgroundColor = @"CLCalendarSelectedDayNumberBackgroundColor";
+NSString *const CLCalendarSelectedCurrentDayNumberBackgroundColor = @"CLCalendarSelectedCurrentDayNumberBackgroundColor";
 NSString *const CLCalendarSelectedDatePrintFormat = @"CLCalendarSelectedDatePrintFormat";
 NSString *const CLCalendarSelectedDatePrintColor = @"CLCalendarSelectedDatePrintColor";
 NSString *const CLCalendarSelectedDatePrintFontSize = @"CLCalendarSelectedDatePrintFontSize";
@@ -44,6 +52,14 @@ NSString *const CLCalendarBackgroundImageColor = @"CLCalendarBackgroundImageColo
 //Default Values
 static NSInteger const CLCalendarWeekStartDayDefault = 1;
 static NSInteger const CLCalendarDayTitleTextColorDefault = 0xC2E8FF;
+static NSInteger const CLCalendarPastDayNumberTextColorDefault = 0x7BD1FF;
+static NSInteger const CLCalendarFutureDayNumberTextColorDefault = 0xFFFFFF;
+static NSInteger const CLCalendarCurrentDayNumberTextColorDefault = 0xFFFFFF;
+static NSInteger const CLCalendarSelectedDayNumberTextColorDefault = 0x34A1FF;
+static NSInteger const CLCalendarSelectedCurrentDayNumberTextColorDefault = 0x0081c1;
+static NSInteger const CLCalendarCurrentDayNumberBackgroundColorDefault = 0x0081c1;
+static NSInteger const CLCalendarSelectedDayNumberBackgroundColorDefault = 0xffffff;
+static NSInteger const CLCalendarSelectedCurrentDayNumberBackgroundColorDefault = 0xffffff;
 static NSString* const CLCalendarSelectedDatePrintFormatDefault = @"EEE, d MMM yyyy";
 static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
 
@@ -63,6 +79,14 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
 
 @property (nonatomic, strong) NSNumber *weekStartConfig;
 @property (nonatomic, strong) UIColor *dayTitleTextColor;
+@property (nonatomic, strong) UIColor *pastDayNumberTextColor;
+@property (nonatomic, strong) UIColor *futureDayNumberTextColor;
+@property (nonatomic, strong) UIColor *currentDayNumberTextColor;
+@property (nonatomic, strong) UIColor *selectedDayNumberTextColor;
+@property (nonatomic, strong) UIColor *selectedCurrentDayNumberTextColor;
+@property (nonatomic, strong) UIColor *currentDayNumberBackgroundColor;
+@property (nonatomic, strong) UIColor *selectedDayNumberBackgroundColor;
+@property (nonatomic, strong) UIColor *selectedCurrentDayNumberBackgroundColor;
 @property (nonatomic, strong) NSString *selectedDatePrintFormat;
 @property (nonatomic, strong) UIColor *selectedDatePrintColor;
 @property (nonatomic) float selectedDatePrintFontSize;
@@ -100,7 +124,23 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
     self.weekStartConfig = attributes[CLCalendarWeekStartDay] ? attributes[CLCalendarWeekStartDay] : [NSNumber numberWithInt:CLCalendarWeekStartDayDefault];
     
     self.dayTitleTextColor = attributes[CLCalendarDayTitleTextColor]? attributes[CLCalendarDayTitleTextColor]:[UIColor colorWithHex:CLCalendarDayTitleTextColorDefault];
-    
+
+    self.pastDayNumberTextColor = attributes[CLCalendarPastDayNumberTextColor] ? attributes[CLCalendarPastDayNumberTextColor] : [UIColor colorWithHex:CLCalendarPastDayNumberTextColorDefault];
+
+    self.futureDayNumberTextColor = attributes[CLCalendarFutureDayNumberTextColor] ? attributes[CLCalendarFutureDayNumberTextColor] : [UIColor colorWithHex:CLCalendarFutureDayNumberTextColorDefault];
+
+    self.currentDayNumberTextColor = attributes[CLCalendarCurrentDayNumberTextColor] ? attributes[CLCalendarCurrentDayNumberTextColor] : [UIColor colorWithHex:CLCalendarCurrentDayNumberTextColorDefault];
+
+    self.selectedDayNumberTextColor = attributes[CLCalendarSelectedDayNumberTextColor] ? attributes[CLCalendarSelectedDayNumberTextColor] : [UIColor colorWithHex:CLCalendarSelectedDayNumberTextColorDefault];
+
+    self.selectedCurrentDayNumberTextColor = attributes[CLCalendarSelectedCurrentDayNumberTextColor] ? attributes[CLCalendarSelectedCurrentDayNumberTextColor] : [UIColor colorWithHex:CLCalendarSelectedCurrentDayNumberTextColorDefault];
+
+    self.currentDayNumberBackgroundColor = attributes[CLCalendarCurrentDayNumberBackgroundColor] ? attributes[CLCalendarCurrentDayNumberBackgroundColor] : [UIColor colorWithHex:CLCalendarCurrentDayNumberBackgroundColorDefault];
+
+    self.selectedDayNumberBackgroundColor = attributes[CLCalendarSelectedDayNumberBackgroundColor] ? attributes[CLCalendarSelectedDayNumberBackgroundColor] : [UIColor colorWithHex:CLCalendarSelectedDayNumberBackgroundColorDefault];
+
+    self.selectedCurrentDayNumberBackgroundColor = attributes[CLCalendarSelectedCurrentDayNumberBackgroundColor] ? attributes[CLCalendarSelectedCurrentDayNumberBackgroundColor] : [UIColor colorWithHex:CLCalendarSelectedCurrentDayNumberBackgroundColorDefault];
+
     self.selectedDatePrintFormat = attributes[CLCalendarSelectedDatePrintFormat]? attributes[CLCalendarSelectedDatePrintFormat] : CLCalendarSelectedDatePrintFormatDefault;
     
     self.selectedDatePrintColor = attributes[CLCalendarSelectedDatePrintColor]? attributes[CLCalendarSelectedDatePrintColor] : [UIColor whiteColor];
@@ -244,6 +284,19 @@ static float const CLCalendarSelectedDatePrintFontSizeDefault = 13.f;
 -(DailyCalendarView *)dailyViewForDate: (NSDate *)date inFrame: (CGRect)frame
 {
     DailyCalendarView *view = [[DailyCalendarView alloc] initWithFrame:frame];
+
+    // text colors
+    view.pastDayNumberTextColor = self.pastDayNumberTextColor;
+    view.futureDayNumberTextColor = self.futureDayNumberTextColor;
+    view.currentDayNumberTextColor = self.currentDayNumberTextColor;
+    view.selectedCurrentDayNumberTextColor = self.selectedCurrentDayNumberTextColor;
+
+    // background colors
+    view.selectedDayNumberTextColor = self.selectedDayNumberTextColor;
+    view.currentDayNumberBackgroundColor = self.currentDayNumberBackgroundColor;
+    view.selectedDayNumberBackgroundColor = self.selectedDayNumberBackgroundColor;
+    view.selectedCurrentDayNumberBackgroundColor = self.selectedCurrentDayNumberBackgroundColor;
+
     view.date = date;
     view.backgroundColor = [UIColor clearColor];
     view.delegate = self;

--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/DailyCalendarView.h
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/DailyCalendarView.h
@@ -17,5 +17,14 @@
 @property (nonatomic, strong) NSDate *date;
 @property (nonatomic) BOOL blnSelected;
 
+@property (nonatomic, strong) UIColor *pastDayNumberTextColor;
+@property (nonatomic, strong) UIColor *futureDayNumberTextColor;
+@property (nonatomic, strong) UIColor *currentDayNumberTextColor;
+@property (nonatomic, strong) UIColor *selectedDayNumberTextColor;
+@property (nonatomic, strong) UIColor *selectedCurrentDayNumberTextColor;
+@property (nonatomic, strong) UIColor *currentDayNumberBackgroundColor;
+@property (nonatomic, strong) UIColor *selectedDayNumberBackgroundColor;
+@property (nonatomic, strong) UIColor *selectedCurrentDayNumberBackgroundColor;
+
 -(void)markSelected:(BOOL)blnSelected;
 @end

--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/DailyCalendarView.m
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/DailyCalendarView.m
@@ -80,22 +80,19 @@
 {
     //    DLog(@"mark date selected %@ -- %d",self.date, blnSelected);
     if([self.date isDateToday]){
-        self.dateLabelContainer.backgroundColor = (blnSelected)?[UIColor whiteColor]: [UIColor colorWithHex:0x0081c1];
+        self.dateLabelContainer.backgroundColor = blnSelected ? self.selectedCurrentDayNumberBackgroundColor : self.currentDayNumberBackgroundColor;
         
-        self.dateLabel.textColor = (blnSelected)?[UIColor colorWithHex:0x0081c1]:[UIColor whiteColor];
+        self.dateLabel.textColor = blnSelected ? self.selectedCurrentDayNumberTextColor : self.currentDayNumberTextColor;
     }else{
-        self.dateLabelContainer.backgroundColor = (blnSelected)?[UIColor whiteColor]: [UIColor clearColor];
+        self.dateLabelContainer.backgroundColor = blnSelected ? self.selectedDayNumberBackgroundColor : [UIColor clearColor];
         
-        self.dateLabel.textColor = (blnSelected)?[UIColor colorWithRed:52.0/255.0 green:161.0/255.0 blue:255.0/255.0 alpha:1.0]:[self colorByDate];
+        self.dateLabel.textColor = blnSelected ? self.selectedDayNumberTextColor : [self colorByDate];
     }
-    
-    
-    
-    
 }
+
 -(UIColor *)colorByDate
 {
-    return [self.date isPastDate]?[UIColor colorWithHex:0x7BD1FF]:[UIColor whiteColor];
+    return [self.date isPastDate] ? self.pastDayNumberTextColor : self.futureDayNumberTextColor;
 }
 
 -(void)dailyViewDidClick: (UIGestureRecognizer *)tap


### PR DESCRIPTION
Hello,

Thank you for your project; I've found it useful, and I appreciate your work on it.

I had a need for additional color customizations, so I added some new attributes to be used through the CLWeeklyCalendarViewDelegate's CLCalendarBehaviorAttributes method:

• CLCalendarPastDayNumberTextColor — The day-of-month number text color for dates in the past
• CLCalendarFutureDayNumberTextColor – The day-of-month number text color for dates in the future
• CLCalendarCurrentDayNumberTextColor — The day-of-month number text color for today
• CLCalendarSelectedDayNumberTextColor — The day-of-month number text color for the selected day when that date is not today
• CLCalendarSelectedCurrentDayNumberTextColor — The day-of-month number text color for the selected day when that date is today
• CLCalendarCurrentDayNumberBackgroundColor — The background color to use for the highlight circle behind the current day when that date isn't selected
• CLCalendarSelectedDayNumberBackgroundColor — The background color to use for the highlight circle behind the selected day when that date is not today
• CLCalendarSelectedCurrentDayNumberBackgroundColor — The background color to use for the highlight circle behind the selected day when that date is today

I'm submitting this pull request in the hopes that you find my changes useful.

Thanks,
E.
